### PR TITLE
psuedo code for override_with_flags

### DIFF
--- a/ml/base/config.py
+++ b/ml/base/config.py
@@ -12,6 +12,7 @@ class MLConfig(object):
             on the instance / class / parent classes. We use it to pass attribute access
             of the MLConfig object directly to its dictionary / munch representation.
         '''
+	
         return getattr(self._internal, attr)
 
     @classmethod
@@ -38,6 +39,27 @@ class MLConfig(object):
     def from_internal_file(cls, config_name):
         pass
 
+    @classmethod
+    def override_with_flag(cls, args_string):
+	args_list=args_string.split('--')
+	
+	#Go through all the flags.
+	for attr_arg in args_list:
+		
+		single_arg=arg.split(' ')
+		attr_name=single_arg[0].split('__')
+		attr_val=single_arg[1]
+		#For each flag, call the recursive function to populate values to the subfield.
+		populate_attr(cls,0,attr_name,attr_val)
+
+	def populate_attr(cls,i,attr_name,attr_val):
+		if i==len(attr_name)-1:
+			__getattr__(cls,attr_name[i])
+
+		populate_attr(cls.attr_name[i],i+1,attr_name,attr_val)
+		
+	
+	
     def __init__(self, global_config, graph, trainer, predictor, io, metric):
         self._internal = global_config
         self.global_config = global_config


### PR DESCRIPTION
This is my current design of overriding configs with flags. After talking with Azhen, I get more clear about Python and how to fix the syntax errors. We are thinking about putting the parsing command lines in config_utils.py and only override the values recursively here in the class. Diu how do you think about this part?
Thanks so much guys!!